### PR TITLE
Droptable Tool Continue on Error if malformed npc data 

### DIFF
--- a/services/m=data/searchtool.js
+++ b/services/m=data/searchtool.js
@@ -231,6 +231,10 @@ export default {
         }
         getExpectedQuantity() {
           let t = 0;
+          if(this.minAmount > this.maxAmount ) {
+            console.error("ERROR WITH DROP ID", this.id, "- MinValue > MaxValue")
+            return(0)
+          }
           const range = Array(this.maxAmount - this.minAmount + 1).fill(1).map((x, y) => this.minAmount + y);
           return ((range.reduce((a, b) => a + b, t) / range.length * (this.rarity / 100))).toFixed(2)
         }


### PR DESCRIPTION
Resolves an issue where if NPCs had a higher minAmount than maxAmount the expected value calculation would fail. I wasn't able to find any other NPCs with this same behavior but there are probably others.

Just returns 0 instead.

Closes [ !218](https://github.com/2009scape/2009scape.github.io/issues/218)