### PR TITLE
Fixed the link for the Source Code

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -44,8 +44,8 @@
 </ul>
 </li>
 
-<li class="top"><a id="login" class="tl" href="https://github.com/2009scape" rel="noopener noreferrer"
-    target="_blank"><span class="tl">Source Code</span></a>
+<li class="top"><a id="login" class="tl" href="https://gitlab.com/2009scape" rel="noopener noreferrer"
+  target="_blank"><span class="tl">Source Code</span></a>
   <ul>
     <li>
     <li><a href="https://gitlab.com/2009scape/2009scape" rel="noopener noreferrer" target="_blank"

--- a/services/m=funorb/gamelist.html
+++ b/services/m=funorb/gamelist.html
@@ -328,7 +328,7 @@
                               >
                             </li>
                             <li>
-                              <a href="https://github.com/2009scape" class="fly"
+                              <a href="https://gitlab.com/2009scape" class="fly"
                                 >2009scape Github</a
                               >
                             </li>

--- a/services/m=funorb/index.html
+++ b/services/m=funorb/index.html
@@ -140,7 +140,7 @@
                           class="fly">Suggest a Game</a></li>
                       <li><a href="https://www.reddit.com/r/Funorb/" class="fly">Funorb Reddit</a></li>
                       <li><a href="https://www.reddit.com/r/2009scape/" class="fly">2009scape Reddit</a></li>
-                      <li><a href="https://github.com/2009scape" class="fly">2009scape Github</a></li>
+                      <li><a href="https://gitlab.com/2009scape" class="fly">2009scape Github</a></li>
                       <li><a href="https://gitlab.com/2009scape" class="fly">2009scape Gitlab</a></li>
                       <li><a href="https://discord.gg/YY7WSttN7H" class="fly last">Discord</a></li>
                     </ul>

--- a/services/m=funorb/info.html
+++ b/services/m=funorb/info.html
@@ -250,7 +250,7 @@
                         <a href="https://www.reddit.com/r/2009scape/" class="fly">2009scape Reddit</a>
                       </li>
                       <li>
-                        <a href="https://github.com/2009scape" class="fly">2009scape Github</a>
+                        <a href="https://gitlab.com/2009scape" class="fly">2009scape Github</a>
                       </li>
                       <li>
                         <a href="https://gitlab.com/2009scape" class="fly">2009scape Gitlab</a>

--- a/site/archives/archived.html
+++ b/site/archives/archived.html
@@ -147,7 +147,7 @@ new_subcat=add_subcat(4, 5, "Postbag from the Hedge", -1 == 5);new_subcat=add_su
             </ul>
           </li>
       
-          <li class="top"><a id="login" class="tl" href="https://github.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
+          <li class="top"><a id="login" class="tl" href="https://gitlab.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
             <ul>
               <li><li><a href="https://gitlab.com/2009scape/2009scape" rel="noopener noreferrer" target="_blank" class="fly"><span>Game Source Code</span></a></li>
               <li><a href="https://github.com/2009scape/2009Scape.github.io" rel="noopener noreferrer" target="_blank" class="fly"><span>Website Source Code</span></a>

--- a/site/archives/archived_hall_of_fame.html
+++ b/site/archives/archived_hall_of_fame.html
@@ -118,7 +118,7 @@ English
                   </ul>
                 </li>
             
-                <li class="top"><a id="login" class="tl" href="https://github.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
+                <li class="top"><a id="login" class="tl" href="https://gitlab.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
                   <ul>
                     <li><li><a href="https://gitlab.com/2009scape/2009scape" rel="noopener noreferrer" target="_blank" class="fly"><span>Game Source Code</span></a></li>
                     <li><a href="https://github.com/2009scape/2009Scape.github.io" rel="noopener noreferrer" target="_blank" class="fly"><span>Website Source Code</span></a>

--- a/site/staff/summer.html
+++ b/site/staff/summer.html
@@ -117,7 +117,7 @@ English
                   </ul>
                 </li>
             
-                <li class="top"><a id="login" class="tl" href="https://github.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
+                <li class="top"><a id="login" class="tl" href="https://gitlab.com/2009scape" rel="noopener noreferrer" target="_blank"><span class="ts">Source Code</span></a>
                   <ul>
                     <li><li><a href="https://gitlab.com/2009scape/2009scape" rel="noopener noreferrer" target="_blank" class="fly"><span>Game Source Code</span></a></li>
                     <li><a href="https://github.com/2009scape/2009Scape.github.io" rel="noopener noreferrer" target="_blank" class="fly"><span>Website Source Code</span></a>


### PR DESCRIPTION
I fixed[ this](https://github.com/2009scape/2009scape.github.io/issues/223) by linking the Gitlab project page when you click directly on the Source Code button. 9/10 people are not looking for the source code to the website, but more so looking for Game related code.

