### PR TITLE
Money making: Update Simon Templeton amount to show range

### DIFF
--- a/site/game_guide/play.html
+++ b/site/game_guide/play.html
@@ -323,7 +323,7 @@ across the bridge in Lumbridge.
 
 <p>
   You will need a way to make sure you don't die of the desert heat and a minimum of 30 agility to get started.
-  The pyramid is straight-forward and when you bring Simon the pyramid top he will give you 10k each.
+  The pyramid is straight-forward and when you bring Simon the pyramid top he will give you 3.7-10k each depending on your agility level.
   <br/>
   <br/>
   <b>Make sure you bring waterskins</b>


### PR DESCRIPTION
This is something that confused me when I got started - I thought I was being ripped off!

The value Simon pays is based on the player's agility level, following the equation `1000 + (({player_agility_level} / 99) * 9000)`. Since the pyramid can only be completed once the user has reached level 30, that gives a possible range of 3727 - 10,000 gp.

See https://gitlab.com/2009scape/2009scape/-/blob/master/Server/src/main/content/region/desert/dialogue/SimonTempleton.java#L56 for the calculation.