### PR TITLE
Update Thanos Tool to Zaros

### DIFF
--- a/site/game_guide/credits.md
+++ b/site/game_guide/credits.md
@@ -32,12 +32,10 @@ Super Easy! Get to testing!
 
 If you are wanting to contribute the smaller easy but yet super imporant stuff look no further than the JSON side.
 What can you contribute through JSON you may ask?
-There are examines, npc stats, npc drops, item drops, and even item spawns you can fill out. 
-Check out our Thanos Tool in order to get started.
+There are examines, npc stats, npc drops, item drops, and even item spawns you can fill out.
+Check out [Zaros](https://gitlab.com/2009scape/tools/rs09-thanos-tool) to get started.
 It's a fill-in-the-blank tool that does just that.
 Make sure that the Information is authentic to the 2009 era.
-
-Click on the [Thanos Tool(https://gitlab.com/2009scape/tools/rs09-thanos-tool) to be redirected to the Gitlab page.
 
 ### Quest Dialogue
 


### PR DESCRIPTION
I was going through the site and noticed some broken markdown formatting on https://2009scape.org/site/game_guide/credits.html

<img width="709" height="164" alt="image" src="https://github.com/user-attachments/assets/30eb7bf9-52fd-49b7-b970-21c9dde90e14" />

This PR fixes the formatting and updates the name from Thanos Tool to Zaros which seems to be the new name for that project (https://gitlab.com/2009scape/tools/rs09-thanos-tool/-/commit/45cb0fa118504b702ea7fe2f75285aea38513d40).